### PR TITLE
Corrected spellings

### DIFF
--- a/modules/ROOT/pages/start-using-sdk.adoc
+++ b/modules/ROOT/pages/start-using-sdk.adoc
@@ -14,7 +14,7 @@ The following sections explain in detail how to get started using each method.
 
 == Installing the Client
 
-The Couchbase .NET SDK is compatable with both Microsoft .NET Framework 4.5 or and Microsoft .NET Core runtimes.
+The Couchbase .NET SDK is compatible with both Microsoft .NET Framework 4.5 or and Microsoft .NET Core runtimes.
 Microsoft Visual Studio 2013 or later is assumed in this guide, though you should use 2015 or later if possible.
 Add the Couchbase .NET SDK to your Visual Studio solution using one of the following methods:
 


### PR DESCRIPTION
Under heading installing the client corrected the spelling of compatible