### PR TITLE
Update beta3 download uri

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -84,7 +84,7 @@ _Note that you can checkout a specific tag for each release as well._
 
 = Version 3.0.0-beta3 (20th Dec 2019)
 
-https://packages.couchbase.com/clients/net/3.0/CouchbaseNetClient.3.0.0-beta3.zip[Download] |  https://docs.couchbase.com/sdk-api/couchbase-net-client-3.0.0-beta3[API Reference] | https://www.nuget.org/packages/CouchbaseNetClient/3.0.0-beta3[Nuget]
+https://packages.couchbase.com/clients/net/3.0/Couchbase-Net-Client-3.0.0-beta3.zip[Download] |  https://docs.couchbase.com/sdk-api/couchbase-net-client-3.0.0-beta3[API Reference] | https://www.nuget.org/packages/CouchbaseNetClient/3.0.0-beta3[Nuget]
 
 === Known Issues
 * https://issues.couchbase.com/browse/NCBC-2187[NCBC-2187]: 


### PR DESCRIPTION
Hi Richard -

This fixes the .zip download link. I am not sure why the docs are not showing because the link seems to be correct.

-Jeff