### PR TITLE
Incorrect property reference

### DIFF
--- a/modules/ROOT/pages/client-settings.adoc
+++ b/modules/ROOT/pages/client-settings.adoc
@@ -661,7 +661,7 @@ var config = new ClientConfiguration
         new Uri(ConfigurationManager.AppSettings["bootstrapUrl"])
     }
 };
-config = ConnectionPoolFactory.GetFactory<ConnectionPool<MultiplexingConnection>>();
+config.ConnectionPoolCreator  = ConnectionPoolFactory.GetFactory<ConnectionPool<MultiplexingConnection>>();
 config.IOServiceCreator = IOServiceFactory.GetFactory<MultiplexingIOService>();
 ClusterHelper.Initialize(config);
 ----


### PR DESCRIPTION
The example will tries to override the config object should be ConnectionPoolCreator