### PR TITLE
CouchbaseNetClient SDK 2.7.21 release

### DIFF
--- a/modules/ROOT/pages/sdk-release-notes.adoc
+++ b/modules/ROOT/pages/sdk-release-notes.adoc
@@ -82,6 +82,26 @@ https://github.com/couchbase/couchbase-net-client/fork
 After you have successfully built the source, it's then just a matter of referencing the binaries (.DLL files) from your consuming project.
 _Note that you can checkout a specific tag for each release as well._
 
+== Version 2.7.21 (1th September 2020)
+
+https://packages.couchbase.com/clients/net/2.7/Couchbase-Net-Client-2.7.21.zip[Download] | 
+// http://docs.couchbase.com/sdk-api/couchbase-net-client-2.7.21[API Reference] |
+https://www.nuget.org/packages/CouchbaseNetClient/2.7.21[Nuget]
+
+=== Known Issues
+This release has the following known issues:
+
+* https://issues.couchbase.com/browse/NCBC-1296[NCBC-1296]:
+.NETCore SDK N1QL query throws System.PlatformNotSupportedException on some .NET Core platforms.
+ A workaround is available.
+* https://issues.couchbase.com/browse/NCBC-1502[NCBC-1502]:
+Certain Prepared statements could produce _Fatal error: unexpected end of JSON input_.
+
+=== Fixed Issues
+
+* https://issues.couchbase.com/browse/NCBC-2616[NCBC-2616]: Ensure that memory stream is open after dispose of writer
+* https://issues.couchbase.com/browse/NCBC-2629[NCBC-2629]: Add Raw parameter to SearchParams
+
 == Version 2.7.20 (6th August 2020)
 
 https://packages.couchbase.com/clients/net/2.7/Couchbase-Net-Client-2.7.20.zip[Download] | 

--- a/modules/ROOT/pages/sdk-release-notes.adoc
+++ b/modules/ROOT/pages/sdk-release-notes.adoc
@@ -82,10 +82,10 @@ https://github.com/couchbase/couchbase-net-client/fork
 After you have successfully built the source, it's then just a matter of referencing the binaries (.DLL files) from your consuming project.
 _Note that you can checkout a specific tag for each release as well._
 
-== Version 2.7.21 (1th September 2020)
+== Version 2.7.21 (1st September 2020)
 
 https://packages.couchbase.com/clients/net/2.7/Couchbase-Net-Client-2.7.21.zip[Download] | 
-// http://docs.couchbase.com/sdk-api/couchbase-net-client-2.7.21[API Reference] |
+http://docs.couchbase.com/sdk-api/couchbase-net-client-2.7.21[API Reference] |
 https://www.nuget.org/packages/CouchbaseNetClient/2.7.21[Nuget]
 
 === Known Issues
@@ -99,8 +99,10 @@ Certain Prepared statements could produce _Fatal error: unexpected end of JSON i
 
 === Fixed Issues
 
-* https://issues.couchbase.com/browse/NCBC-2616[NCBC-2616]: Ensure that memory stream is open after dispose of writer
-* https://issues.couchbase.com/browse/NCBC-2629[NCBC-2629]: Add Raw parameter to SearchParams
+* https://issues.couchbase.com/browse/NCBC-2616[NCBC-2616]: 
+FixeS a bug where the stream writer is causing the recyclable memory stream to be disposed prior to the `ToArray` call being made.
+* https://issues.couchbase.com/browse/NCBC-2629[NCBC-2629]: 
+Added Raw parameter to SearchParams.
 
 == Version 2.7.20 (6th August 2020)
 


### PR DESCRIPTION
2.7.21 release notes.  Links will be verified after build files are uploaded.