### PR TITLE
Added link to VS code

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -23,7 +23,7 @@ The library is distributed in a number of ways:
 
 == Hello Couchbase
 
-Start a new console project (in Visual Studio or VS Code, etc). 
+Start a new console project (in Visual Studio or https://code.visualstudio.com/[VS Code], etc). 
 Install the latest 3.0 CouchbaseNetClient NuGet package.
 
 The following code samples assume:


### PR DESCRIPTION
Hi -  Added link to VS code for quick redirection

Start a new console project (in Visual Studio or https://code.visualstudio.com/[VS Code], etc). 
Install the latest 3.0 CouchbaseNetClient NuGet package.

Thanks,
Ashish