### PR TITLE
Fix: code block in the doc does not display correctly

### DIFF
--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -54,7 +54,10 @@ In most cases your query will return more than one result, and you may be lookin
 [source,csharp,indent=0]
 ----
 include::example$/n1ql-queries-sdk/n1ql-queries-sdk/Program.cs[tag=namedparameter]
+----
 
+[source,csharp,indent=0]
+----
 include::example$/n1ql-queries-sdk/n1ql-queries-sdk/Program.cs[tag=namedparameter2]
 ----
 


### PR DESCRIPTION
The C# code block in the doc does not display correctly, and the `View On Github` icon doesn't show up. I wasn't 100% sure of your purpose, you can decide whether to merge this PR or revise the document based on the actual situation.

![image](https://user-images.githubusercontent.com/6244148/126874671-fa9a6c2b-8e32-4a43-a12c-92bcb0879682.png)
