### PR TITLE
Gardening 3.2.0 release notes

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -438,8 +438,9 @@ https://www.nuget.org/packages/CouchbaseNetClient/3.1.1[Nuget]
 
 * https://issues.couchbase.com/browse/NCBC-2565[NCBC-2565]:
 WaitUntilReady failure for 6.5.
-* https://issues.couchbase.com/browse/NCBC-2660[NCBC-2660]:
-Operations are not retried if they hit an open circuit breaker.
+* https://issues.couchbase.com/browse/NCBC-2660[NCBC-2660],
+https://issues.couchbase.com/browse/NCBC-2935[NCBC-2935]:
+Operations are now retried if they hit an open circuit breaker.
 * https://issues.couchbase.com/browse/NCBC-2693[NCBC-2693]:
 MutationToken.GetHashCode() implementation looks suspect.
 * https://issues.couchbase.com/browse/NCBC-2694[NCBC-2694]:

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -121,70 +121,95 @@ TimeoutExceptions continue after rebound in Failover/Eject tests.
 
 === Fixed Issues
 
-* https://issues.couchbase.com/browse/NCBC-2660[NCBC-2660]:Operations are not retried if they hit an open circuit breaker
-* https://issues.couchbase.com/browse/NCBC-2719[NCBC-2719]:User Management quick snippets are missing in .NET
-* https://issues.couchbase.com/browse/NCBC-2730[NCBC-2730]:Partition information is not exposed by query management API
-* https://issues.couchbase.com/browse/NCBC-2841[NCBC-2841]:scope.AnalyticsQueryAsync may construct Dataset query_context incorrectly?
-* https://issues.couchbase.com/browse/NCBC-2851[NCBC-2851]:TimeoutExceptions continue after rebound in Failover/Eject tests
-* https://issues.couchbase.com/browse/NCBC-2853[NCBC-2853]:Ensure FF Maps is only used after a NMVB
-* https://issues.couchbase.com/browse/NCBC-2880[NCBC-2880]:Combi test failure: Test_Collections_DataverseCollectionQuery
-* https://issues.couchbase.com/browse/NCBC-2889[NCBC-2889]:NuGet link has a broken reference to the release notes
-* https://issues.couchbase.com/browse/NCBC-2890[NCBC-2890]:Enable and collect server duration for tracing
-* https://issues.couchbase.com/browse/NCBC-2891[NCBC-2891]:Send 0x0 for default scope/collections for certain 7.0.0 beta versions
-* https://issues.couchbase.com/browse/NCBC-2894[NCBC-2894]:Make Increment/decrement CAS option obsolete
-* https://issues.couchbase.com/browse/NCBC-2899[NCBC-2899]:Logging Meter prints every 10 seconds instead of 600
-* https://issues.couchbase.com/browse/NCBC-2900[NCBC-2900]:LoggingMeter  does  not include percentile values
-* https://issues.couchbase.com/browse/NCBC-2902[NCBC-2902]:LoggingMeter Output Format not per RFC
-* https://issues.couchbase.com/browse/NCBC-2903[NCBC-2903]:Leftovers from AggregatingMeter to LoggingMeter
-* https://issues.couchbase.com/browse/NCBC-2904[NCBC-2904]:LoggingMeter JSON output should be terse by default
-* https://issues.couchbase.com/browse/NCBC-2905[NCBC-2905]:ThresholdLoggingTracer should omit null values
-* https://issues.couchbase.com/browse/NCBC-2906[NCBC-2906]:ThresholdLoggingTracer should include timeout
-* https://issues.couchbase.com/browse/NCBC-2907[NCBC-2907]:ThresholdLoggingTracer should be enabled by default
-* https://issues.couchbase.com/browse/NCBC-2908[NCBC-2908]:ThresholdLoggingTracer still printing old format
-* https://issues.couchbase.com/browse/NCBC-2909[NCBC-2909]:Query Metrics not included if metrics(true)
-* https://issues.couchbase.com/browse/NCBC-2910[NCBC-2910]:ThresholdLoggingTracer only includes KV
-* https://issues.couchbase.com/browse/NCBC-2916[NCBC-2916]:Add &quot;operation&quot; property to LoggingMeterReport output
-* https://issues.couchbase.com/browse/NCBC-2917[NCBC-2917]:Fixup breaking query unit test
-* https://issues.couchbase.com/browse/NCBC-2921[NCBC-2921]:Value was either too large or too small for an Int32
-* https://issues.couchbase.com/browse/NCBC-2923[NCBC-2923]:Allow custom IRequestTracer to be configured in ClusterOptions
-* https://issues.couchbase.com/browse/NCBC-2924[NCBC-2924]:DateParseHandling not carried through from SerializerSettings to DefaultStreamingJsonReader
-* https://issues.couchbase.com/browse/NCBC-2927[NCBC-2927]:OOO Disabled By Default
-* https://issues.couchbase.com/browse/NCBC-2928[NCBC-2928]:KV Tracer Output Not Aligning with Spec
-* https://issues.couchbase.com/browse/NCBC-2929[NCBC-2929]:LoggingMeter emit_interval_s wrong unit
-* https://issues.couchbase.com/browse/NCBC-2930[NCBC-2930]:Collection and scope not found not parsing errors correctly
-* https://issues.couchbase.com/browse/NCBC-2931[NCBC-2931]:CollectionIdChanged_RetriesAutomatically test failing
-* https://issues.couchbase.com/browse/NCBC-2933[NCBC-2933]:Unit Tests are being skipped in Jenkins Pipeline
-* https://issues.couchbase.com/browse/NCBC-2934[NCBC-2934]:Fix failing Unit Tests
+* https://issues.couchbase.com/browse/NCBC-2660[NCBC-2660]:
+After a failure that causes the circuit breaker to open, such as full send queue, new operation will immediately fail with CircuitBreakerException. The retry orchestrator now retries in this situation, preventing silent failure.
+* https://issues.couchbase.com/browse/NCBC-2730[NCBC-2730]:
+Expose Partition Information in Query Management API.
+* https://issues.couchbase.com/browse/NCBC-2841[NCBC-2841]:
+Construct `query_context` in Analytics queries correctly, fixing a bug with datasets that required escaping with backticks.
+* https://issues.couchbase.com/browse/NCBC-2853[NCBC-2853]: After a `not_my_vbucket` exception during a rebalance, use a Fast-forward map, if available, to locate the correct vbucket.
+* https://issues.couchbase.com/browse/NCBC-2880[NCBC-2880]:
+Analytics fix and refactor to improve testability.
+* https://issues.couchbase.com/browse/NCBC-2890[NCBC-2890]:
+Enable and collect server duration for tracing.
+* https://issues.couchbase.com/browse/NCBC-2891[NCBC-2891]:
+Fixes a bug where the CID for the default Scope/Collection was not passed to some 7.0beta server versions.
+* https://issues.couchbase.com/browse/NCBC-2894[NCBC-2894]:
+Remove unsupported CAS setting from Increment/DecrementOptions
+* https://issues.couchbase.com/browse/NCBC-2929[NCBC-2929],
+https://issues.couchbase.com/browse/NCBC-2899[NCBC-2899]:
+Correct Logging Meter emit_interval to output every 600 seconds.
+* https://issues.couchbase.com/browse/NCBC-2903[NCBC-2903]:
+Remove reference to AggregatingMeter, which has been superseded by LoggingMeter.
+* https://issues.couchbase.com/browse/NCBC-2900[NCBC-2900],
+https://issues.couchbase.com/browse/NCBC-2902[NCBC-2902],
+https://issues.couchbase.com/browse/NCBC-2904[NCBC-2904]:
+Align LoggingMeter Output Format with RFC, adding percentile values and setting JSON output to terse by default, instead of pretty.
+* https://issues.couchbase.com/browse/NCBC-2905[NCBC-2905],
+https://issues.couchbase.com/browse/NCBC-2906[NCBC-2906],
+https://issues.couchbase.com/browse/NCBC-2907[NCBC-2907],
+https://issues.couchbase.com/browse/NCBC-2908[NCBC-2908]:
+Align ThresholdLoggingTracer Output with RFC, and enable by default.
+Now correctly omits null fields in JSON output, includes timeout.
+* https://issues.couchbase.com/browse/NCBC-2916[NCBC-2916]:
+Add "operation" property to allow LoggingMeterReport output to be split by opcode.
+* https://issues.couchbase.com/browse/NCBC-2928[NCBC-2928]:
+Align Threshold Logger output with KV Tracer Output spec.
+* https://issues.couchbase.com/browse/NCBC-2921[NCBC-2921]:
+Fix a bug where the quota.rawRAM size may over/under flow the Int32 size of the BucketSettings.RamQuotaMB field when the JSON is parsed.
+* https://issues.couchbase.com/browse/NCBC-2924[NCBC-2924]:
+Fix a bug where Date Time Offsets were always coverted to local time zone, by passing DateParseHandling from SerializerSettings to the DefaultStreamingJsonReader.
+* https://issues.couchbase.com/browse/NCBC-2927[NCBC-2927]:
+Requests and responses will be handled in an Out-of-Order manner by default.
+* https://issues.couchbase.com/browse/NCBC-2930[NCBC-2930]:
+Update Collection and Scope error parsing
+* https://issues.couchbase.com/browse/NCBC-2931[NCBC-2931]:
+Fixes a bug where when the Collection id changes, those changes were not picked up causing an operation timeout.
+* https://issues.couchbase.com/browse/NCBC-2933[NCBC-2933],
+https://issues.couchbase.com/browse/NCBC-2934[NCBC-2934]:
+Unit Test improvements and fixes to Jenkins Pipeline.
 
 === New Features and Behavioral Changes.
 
-* https://issues.couchbase.com/browse/NCBC-2869[NCBC-2869]:OpenTelemetry tracing module
-* https://issues.couchbase.com/browse/NCBC-2893[NCBC-2893]:Allow external spans to be imported as a parent span
-* https://issues.couchbase.com/browse/NCBC-1973[NCBC-1973]:.NET Doc on Error Handling for SDK 3 v1
-* https://issues.couchbase.com/browse/NCBC-2913[NCBC-2913]:Add single query node routing capability
-* https://issues.couchbase.com/browse/NCBC-2856[NCBC-2856]:Add Orphaned Response Logging to SDK
-* https://issues.couchbase.com/browse/NCBC-2882[NCBC-2882]:Support Query Node affinity for Transactions
-* https://issues.couchbase.com/browse/NCBC-2895[NCBC-2895]:create 3.2 release test ticket
-* https://issues.couchbase.com/browse/NCBC-2896[NCBC-2896]:Release 3.2 SDK
-* https://issues.couchbase.com/browse/NCBC-2911[NCBC-2911]:Travel Sample App with Collections
-* https://issues.couchbase.com/browse/NCBC-2926[NCBC-2926]:Add license to footer of all files in Couchbase project
-* https://issues.couchbase.com/browse/NCBC-2574[NCBC-2574]:Manage Remote Links
-* https://issues.couchbase.com/browse/NCBC-2575[NCBC-2575]:Update analytics management API to support compound dataverse names.
-* https://issues.couchbase.com/browse/NCBC-2581[NCBC-2581]:Provide Tracing Interface
-* https://issues.couchbase.com/browse/NCBC-2585[NCBC-2585]:Build Support for Ubuntu 20.04 LTS
-* https://issues.couchbase.com/browse/NCBC-2699[NCBC-2699]:Add Field Level Encryption Support
-* https://issues.couchbase.com/browse/NCBC-2717[NCBC-2717]:Upgrade/Support to .NET 5.0
-* https://issues.couchbase.com/browse/NCBC-2777[NCBC-2777]:Docs Field Level Encryption .NET
-* https://issues.couchbase.com/browse/NCBC-2786[NCBC-2786]:SDK 3.2 Documentation Changes
-* https://issues.couchbase.com/browse/NCBC-2787[NCBC-2787]:SDK 3.2 Code Sample Changes - Named Scope and Collections
-* https://issues.couchbase.com/browse/NCBC-2790[NCBC-2790]:Add Support to Preserve TTL
-* https://issues.couchbase.com/browse/NCBC-2800[NCBC-2800]:Provide Metrics Interface
-* https://issues.couchbase.com/browse/NCBC-2807[NCBC-2807]:Deprecate Collection Manager GetScope()
-* https://issues.couchbase.com/browse/NCBC-2846[NCBC-2846]:SDK Error Handling - LCB_CAS_MISMATCH (209)
-* https://issues.couchbase.com/browse/NCBC-2886[NCBC-2886]:Couchbase Server 7.0 and SDK Compatibility Matrix
-* https://issues.couchbase.com/browse/NCBC-2892[NCBC-2892]:Update .NET Platform Compatibility
-* https://issues.couchbase.com/browse/NCBC-2912[NCBC-2912]:Map Query Error 13014 to AuthenticationException.
-* https://issues.couchbase.com/browse/NCBC-2932[NCBC-2932]:Transactions Query support requires Cause field on Query.Error
+* https://issues.couchbase.com/browse/NCBC-2869[NCBC-2869]:
+Provide OpenTelemetry tracing module, allowing export via any of the OpenTelemetry exporters such as ZipKin, Jaeger, etc.
+* https://issues.couchbase.com/browse/NCBC-2893[NCBC-2893]:
+Allow a parent span to added to the options for each service or operation for tracing.
+* https://issues.couchbase.com/browse/NCBC-2856[NCBC-2856],
+https://issues.couchbase.com/browse/NCBC-2923[NCBC-2923]:
+Add Orphaned Response Logging to SDK.
+* https://issues.couchbase.com/browse/NCBC-2911[NCBC-2911]:
+Travel Sample App added, with examples of Collections and Scopes across Query, KV, and Search.
+* https://issues.couchbase.com/browse/NCBC-2926[NCBC-2926]:
+Add license to footer of all files in Couchbase project
+* https://issues.couchbase.com/browse/NCBC-2574[NCBC-2574],
+https://issues.couchbase.com/browse/NCBC-2575[NCBC-2575]:
+Analytics management: manage Remote Links, support compound dataverse names.
+* https://issues.couchbase.com/browse/NCBC-2581[NCBC-2581],
+https://issues.couchbase.com/browse/NCBC-2800[NCBC-2800]:
+Provide tracing for the .NET SDK based upon RFC 67 Extended SDK Observability.
+Implements Threshold Logger, LoggingMeter for latency metrics.
+* https://issues.couchbase.com/browse/NCBC-2585[NCBC-2585],
+https://issues.couchbase.com/browse/NCBC-2717[NCBC-2717]:
+Add build Support for .NET 5.0 and Ubuntu 20.04 LTS
+* https://issues.couchbase.com/browse/NCBC-2892[NCBC-2892],
+https://issues.couchbase.com/browse/NCBC-2886[NCBC-2886],
+https://issues.couchbase.com/browse/NCBC-2889[NCBC-2889]:
+Update and correct links for 3.2.0 release.
+* https://issues.couchbase.com/browse/NCBC-2699[NCBC-2699],
+https://issues.couchbase.com/browse/NCBC-2777[NCBC-2777]:
+Provide a framework for client-side encryption of sensitive fields in JSON documents using Field Level Encryption.
+* https://issues.couchbase.com/browse/NCBC-2790[NCBC-2790]:
+Replace, Upsert and MutateIn support `PersistTtl` in servers >= 7.0 which keeps subsequent calls from modifiying the original TTL value on update.
+* https://issues.couchbase.com/browse/NCBC-2807[NCBC-2807]:
+Deprecate Collection Manager `GetScope()` in favour of `GetAllScopes()`
+* https://issues.couchbase.com/browse/NCBC-2846[NCBC-2846]:
+Distinguish between CAS mismatch and DML failure on query error.
+* https://issues.couchbase.com/browse/NCBC-2912[NCBC-2912],
+https://issues.couchbase.com/browse/NCBC-2917[NCBC-2917]:
+Ensure that a server response 13014 is also recognized as an authentication failure by the query parser.
+* https://issues.couchbase.com/browse/NCBC-2932[NCBC-2932]:
+Add Cause field on Query.Error for Transactions Query support.
 
 
 == Version 3.1.7 (02 June 2021)


### PR DESCRIPTION
(added docs/.NET teams to review, as first time I've done this gardening task, feedback welcome!) 

* Reword in a more user-centric way (often using the excellent Gerrit summaries)
 * Group together related changes, either on adjacent lines, or brought onto the
   same line summary.
 * Reformat over multiple lines to make source more manageable
 * Remove a few issues
  - NCBC-2851 was listed in Fixed as well as Known issues
  - Various tickets for updating docs for 3.2.0, as that seems rather niche/meta
    (a few on compatibility updates/link corrections are retained)
  - Some tickets which were still Open/In Progress or Resolved as "Incomplete" or similar.
    I've asked for clarification in some more obviously borderline cases.