### PR TITLE
3.1.7 known issue

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -224,6 +224,8 @@ https://www.nuget.org/packages/CouchbaseNetClient/3.1.7[Nuget]
 
 * https://issues.couchbase.com/browse/NCBC-2851[NCBC-2851]:
 TimeoutExceptions continue after rebound in Failover/Eject tests.
+* https://issues.couchbase.com/browse/NCBC-2891[NCBC-2891]:
+Send 0x0 for default scope/collections for certain Server 7.0 beta versions.
 
 === Fixed Issues
 


### PR DESCRIPTION
Folded in from https://github.com/couchbase/docs-sdk-dotnet/pull/194/
as 3.1.7 now includes the 3.2 page