### PR TITLE
Run descriptionizer on all adoc files

### DIFF
--- a/modules/concept-docs/pages/analytics-for-sdk-users.adoc
+++ b/modules/concept-docs/pages/analytics-for-sdk-users.adoc
@@ -1,10 +1,11 @@
 = Analytics
+:description: Parallel data management for complex queries over many records, using a familiar N1QL-like syntax.
 :nav-title: Analytics for SDK Users
 :page-topic-type: concept
 :page-aliases: analytics,
 
 [abstract]
-Parallel data management for complex queries over many records, using a familiar N1QL-like syntax.
+{description}
 
 
 

--- a/modules/concept-docs/pages/buckets-and-clusters.adoc
+++ b/modules/concept-docs/pages/buckets-and-clusters.adoc
@@ -1,4 +1,5 @@
 = Buckets and Clusters
+:description: The Couchbase .NET SDK provides an API for managing a Couchbase cluster programmatically.
 :navtitle: Buckets & Clusters
 :page-topic-type: concept
 :page-aliases: managing-clusters
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-The Couchbase .NET SDK provides an API for managing a Couchbase cluster programmatically.
+{description}
 
 include::{version-server}@sdk:shared:partial$clusters-buckets.adoc[tag=management]
 

--- a/modules/concept-docs/pages/compression.adoc
+++ b/modules/concept-docs/pages/compression.adoc
@@ -1,4 +1,5 @@
 = Compression
+:description: In response to increasing volumes of data being sent over the wire, Couchbase Data Platform now provides data compression between the SDK and Couchbase Server.
 :page-topic-type: concept
 :page-edition: Enterprise Edition
 :page-aliases:ROOT:compression-intro,compression-intro
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-In response to increasing volumes of data being sent over the wire, Couchbase Data Platform now provides data compression between the SDK and Couchbase Server.
+{description}
 However, stable Snappy support is not yet available in .NET.
 
 

--- a/modules/concept-docs/pages/compression.adoc
+++ b/modules/concept-docs/pages/compression.adoc
@@ -1,5 +1,5 @@
 = Compression
-:description: In response to increasing volumes of data being sent over the wire, Couchbase Data Platform now provides data compression between the SDK and Couchbase Server.
+:description: Data compression to reduce traffic costs from app to Server. 
 :page-topic-type: concept
 :page-edition: Enterprise Edition
 :page-aliases:ROOT:compression-intro,compression-intro
@@ -7,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-{description}
+In response to increasing volumes of data being sent over the wire, Couchbase Data Platform now provides data compression between the SDK and Couchbase Server.
 However, stable Snappy support is not yet available in .NET.
 
 

--- a/modules/concept-docs/pages/concepts.adoc
+++ b/modules/concept-docs/pages/concepts.adoc
@@ -1,8 +1,9 @@
 = Concepts
+:description: link:project-docs:partial$attributes.adoc[]
 :navtitle: Concepts
 :page-topic-type: landing-page
 
-include::project-docs:partial$attributes.adoc[]
+{description}
 
 include::{version-server}@sdk:shared:partial$concepts.adoc[tag=concepts]
 

--- a/modules/concept-docs/pages/data-model.adoc
+++ b/modules/concept-docs/pages/data-model.adoc
@@ -1,10 +1,11 @@
 = The Data Model
+:description: Couchbase's use of JSON as a storage format allows powerful search and query over documents.
 :nav-title: Data Model
 :page-topic-type: concept
 :page-aliases: ROOT:core-operations, ROOT:datastructures
 
 [abstract]
-Couchbase's use of JSON as a storage format allows powerful search and query over documents.
+{description}
 Several data structures are supported by the SDK, including map, list, queue, and set.
 
 

--- a/modules/concept-docs/pages/documents.adoc
+++ b/modules/concept-docs/pages/documents.adoc
@@ -1,4 +1,5 @@
 = Document
+:description: Couchbase supports CRUD operations, various data structures, and binary documents.
 :nav-title: Documents & Doc Ops
 :page-topic-type: concept
 :page-aliases: ROOT:documents,ROOT:documents-basics,ROOT:documents-atomic
@@ -7,7 +8,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Couchbase supports CRUD operations, various data structures, and binary documents.
+{description}
 
 Although query and path-based (Sub-Document) services are available, the simplicity of the document-based kv interface is the fastest way to perform operations involving single documents.
 

--- a/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
+++ b/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
@@ -1,11 +1,12 @@
 = Durability & Failure
+:description: Data durability refers to the fault tolerance and persistence of data in the face of software or hardware failure.
 :page-topic-type: concept
 // :page-aliases: ROOT:failure-considerations,ROOT:durability,ROOT:enhanced-durability
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Data durability refers to the fault tolerance and persistence of data in the face of software or hardware failure.
+{description}
 Even the most reliable software and hardware might fail at some point, and along with the failures, introduce a chance of data loss.
 Couchbase’s durability features include Synchronous Replication, and the possibility to use distributed, multi-document ACID transactions.
 It is the responsibility of the development team and the software architect to evaluate the best choice for each use case.

--- a/modules/concept-docs/pages/errors.adoc
+++ b/modules/concept-docs/pages/errors.adoc
@@ -1,5 +1,5 @@
 = Errors, Exceptions, and Diagnostics
-:description: When the unexpected happens, take a step-by-step approach. .
+:description: When the unexpected happens, take a step-by-step approach.
 :nav-title: Errors & Diagnostics
 :page-topic-type: concept
 :page-aliases:

--- a/modules/concept-docs/pages/errors.adoc
+++ b/modules/concept-docs/pages/errors.adoc
@@ -1,4 +1,5 @@
 = Errors, Exceptions, and Diagnostics
+:description: When the unexpected happens, take a step-by-step approach. .
 :nav-title: Errors & Diagnostics
 :page-topic-type: concept
 :page-aliases:
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-When the unexpected happens, take a step-by-step approach. .
+{description}
 
 
 

--- a/modules/concept-docs/pages/health-check.adoc
+++ b/modules/concept-docs/pages/health-check.adoc
@@ -1,4 +1,5 @@
 = Health Check
+:description: Health Check provides ping() and diagnostics() tests for the health of the network and the cluster.
 :nav-title: Health Check
 :page-topic-type: concept
 :page-aliases: ROOT:health-check
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Health Check provides ping() and diagnostics() tests for the health of the network and the cluster.
+{description}
 
 
 include::{version-server}@sdk:pages:partial$health-check.adoc[tag="intro"]

--- a/modules/concept-docs/pages/n1ql-query.adoc
+++ b/modules/concept-docs/pages/n1ql-query.adoc
@@ -1,4 +1,5 @@
 = Querying with N1QL
+:description: Parallel data management for complex queries over many records, using a familiar SQL-like syntax.
 :nav-title: Querying with N1QL
 :page-topic-type: concept
 :page-aliases: ROOT:n1ql-query,ROOT:prepared-statements,ROOT:querying
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Parallel data management for complex queries over many records, using a familiar SQL-like syntax.
+{description}
 
 
 include::{version-server}@sdk:shared:partial$n1ql-queries.adoc[tag=intro]

--- a/modules/concept-docs/pages/nonjson.adoc
+++ b/modules/concept-docs/pages/nonjson.adoc
@@ -1,4 +1,5 @@
 = Non-JSON Documents
+:description: Binary formats & Transcoders
 :nav-title: Non-JSON
 :page-aliases: ROOT:nonjson
 :page-topic-type: concept
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Binary formats & Transcoders
+{description}
 
 include::{version-server}@sdk:shared:partial$nonjson.adoc[tag=intro]
 

--- a/modules/concept-docs/pages/xattr.adoc
+++ b/modules/concept-docs/pages/xattr.adoc
@@ -1,4 +1,5 @@
 = Extended Attributes
+:description: Extended Attributes (XATTR) are metadata that can be provided on a per-application basis.
 :nav-title: XATTR
 :page-topic-type: concept
 :page-aliases: sdk-xattr-overview,ROOT:sdk-xattr-overview
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Extended Attributes (XATTR) are metadata that can be provided on a per-application basis.
+{description}
 
 include::{version-server}@sdk:shared:partial$sdk-xattr-overview.adoc[tag=intro_extended_attributes]
 

--- a/modules/hello-world/pages/dotnet-environment.adoc
+++ b/modules/hello-world/pages/dotnet-environment.adoc
@@ -1,6 +1,7 @@
 = Using Couchbase .NET SDK with Visual Studio 2019 or VSCode
+:description: The following document explains how to get up in running developing applications with the new Couchbase .NET SDK 3.0.
 
-The following document explains how to get up in running developing applications with the new Couchbase .NET SDK 3.0.
+{description}
 The SDK is based off of the .NET Standard 2.0 and supports development targeting various platforms: Windows, Linux and MacOS.
 
 

--- a/modules/hello-world/pages/platform-help.adoc
+++ b/modules/hello-world/pages/platform-help.adoc
@@ -1,9 +1,10 @@
 = Setting Up Couchbase .NET SDK with Visual Studio 2019 or VSCode
+:description: pass:q[Discover how to get up and running developing applications with the Couchbase .NET SDK 3.0+ using `Visual Studio 2019` or `Visual Studio Code`.]
 :page-aliases: ROOT:platform-introduction,ROOT:platform-help,
 :navtitle: Setting Up the .NET SDK
 
 [abstract]
-Discover how to get up and running developing applications with the Couchbase .NET SDK 3.0+ using `Visual Studio 2019` or `Visual Studio Code`. 
+{description}
 
 
 A simple .NET orientation intro for _non-_.NET folk who are evaluating the Couchbase .NET SDK.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -1,11 +1,12 @@
 = Install and Start Using the .NET SDK with Couchbase Server
+:description: The Couchbase .NET SDK enables you to interact with a Couchbase Server cluster from .NET using C# and other .NET languages.
 :page-aliases: ROOT:getting-started,ROOT:start-using,ROOT:hello-couchbase,ROOT:start-using-sdk
 :navtitle: Start Using the SDK
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-The Couchbase .NET SDK enables you to interact with a Couchbase Server cluster from .NET using C# and other .NET languages.
+{description}
 It offers an asynchronous API based on the _Task-based Asynchronous Pattern (TAP)_.
 
 The Couchbase .NET client allows applications to connect to Couchbase Server using any Common Language Runtime (CLR) language, including C#, F#, and VB.NET.

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -1,11 +1,12 @@
 = Analytics using the .NET SDK
+:description: Parallel data management for complex queries over many records, using a familiar N1QL-like syntax.
 :page-topic-type: howto
 :page-edition: Enterprise Edition:
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Parallel data management for complex queries over many records, using a familiar N1QL-like syntax.
+{description}
 
 
 

--- a/modules/howtos/pages/caching-example.adoc
+++ b/modules/howtos/pages/caching-example.adoc
@@ -1,7 +1,8 @@
 = Caching Example Use Case
+:description: A walk-through of the basics of Key-Value operations with Couchbase, through the lens of a REST api caching layer.
 
 [abstract]
-A walk-through of the basics of Key-Value operations with Couchbase, through the lens of a REST api caching layer.
+{description}
 
 == Prerequisites
 This example uses https://github.com/aspnet/AspNetCore[ASP.NET Core] as a web-framework for a C# REST API, and version 3 of the Couchbase SDK (available on Nuget).

--- a/modules/howtos/pages/collecting-information-and-logging.adoc
+++ b/modules/howtos/pages/collecting-information-and-logging.adoc
@@ -1,9 +1,10 @@
 = Collecting Information and Logging in the .NET SDK with Couchbase Server
+:description: pass:q[Couchbase .NET SDK3 relies on the Microsoft.Extensions.Logging API and specifically on the `Microsoft.Extensions.Logging.ILoggerFactory` interface to support a wide variety of compatible 3rd party logging implementations such as Serilog, NLog, and others.]
 :navtitle: Collecting Information
 :page-aliases: ROOT:event-bus-metrics,ROOT:logging,ROOT:collecting-information-and-logging
 
 [abstract]
-Couchbase .NET SDK3 relies on the Microsoft.Extensions.Logging API and specifically on the `Microsoft.Extensions.Logging.ILoggerFactory` interface to support a wide variety of compatible 3rd party logging implementations such as Serilog, NLog, and others. 
+{description}
 Further details can be found in the Microsoft documentation for https://docs.microsoft.com/en-us/dotnet/core/extensions/logging[Logging^] and https://docs.microsoft.com/en-us/dotnet/core/extensions/logging-providers[Logging Providers^].
 
 

--- a/modules/howtos/pages/concurrent-async-apis.adoc
+++ b/modules/howtos/pages/concurrent-async-apis.adoc
@@ -1,4 +1,5 @@
 = Choosing an API
+:description: pass:q[The Couchbase .NET SDK uses the _Task-based Asynchronous Pattern (TAP)_ using types in the System.Threading.Tasks namespace to represent asynchronous operations against the Couchbase Server which can be awaited via the `await` keyword.]
 :navtitle: Choosing an API
 :page-topic-type: howto
 :page-aliases: ROOT:async-programming,ROOT:batching-operations
@@ -6,7 +7,7 @@
 
 
 [abstract]
-The Couchbase .NET SDK uses the _Task-based Asynchronous Pattern (TAP)_ using types in the System.Threading.Tasks namespace to represent asynchronous operations against the Couchbase Server which can be awaited via the `await` keyword. There is no separate synchronous API, however, all tasks can be run synchronously in a blocking fashion using the `Task.Result` method. Batching may be done with Task.WhenAll.
+{description} There is no separate synchronous API, however, all tasks can be run synchronously in a blocking fashion using the `Task.Result` method. Batching may be done with Task.WhenAll.
 
 
 A couple of points to consider:

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -1,4 +1,5 @@
 = Distributed Transactions from the .NET SDK
+:description: A practical guide to using Couchbase’s distributed ACID transactions, via the .NET API.
 :navtitle: ACID Transactions
 :page-topic-type: howto
 :page-aliases: acid-transactions.adoc
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-A practical guide to using Couchbase’s distributed ACID transactions, via the .NET API.
+{description}
 
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=intro]

--- a/modules/howtos/pages/durability-error-handling-from-the-sdk.adoc
+++ b/modules/howtos/pages/durability-error-handling-from-the-sdk.adoc
@@ -1,8 +1,9 @@
 = Durability in Action
+:description: Data durability is handled by Couchbase Server, but the application programmer needs to code for the best way of handling problems for their particular application.
 :page-topic-type: howto
 
 [abstract]
-Data durability is handled by Couchbase Server, but the application programmer needs to code for the best way of handling problems for their particular application.
+{description}
 This example case covers timeouts, node failures, and how to deal with both Couchbase Server's Synchronous Replication, and the older Server versions' Enhanced Durability.
 
 

--- a/modules/howtos/pages/durability-error-handling-from-the-sdk.adoc
+++ b/modules/howtos/pages/durability-error-handling-from-the-sdk.adoc
@@ -1,9 +1,9 @@
 = Durability in Action
-:description: Data durability is handled by Couchbase Server, but the application programmer needs to code for the best way of handling problems for their particular application.
+:description: Handling data durability with Couchbase Server.
 :page-topic-type: howto
 
 [abstract]
-{description}
+Data durability is handled by Couchbase Server, but the application programmer needs to code for the best way of handling problems for their particular application.
 This example case covers timeouts, node failures, and how to deal with both Couchbase Server's Synchronous Replication, and the older Server versions' Enhanced Durability.
 
 

--- a/modules/howtos/pages/durability.adoc
+++ b/modules/howtos/pages/durability.adoc
@@ -1,10 +1,11 @@
 
 = Durability
+:description: Durability must be traded off against performance.
 :navtitle: Durability
 :page-topic-type: landing-page
 
 [abstract]
-Durability must be traded off against performance.
+{description}
 
 
 

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -1,10 +1,11 @@
 = Field Level Encryption from the .NET SDK
+:description: A practical guide for getting started with Field-Level Encryption, showing how to encrypt and decrypt JSON fields using the .NET SDK.
 :page-topic-type: howto
 :page-edition: Enterprise Edition
 // :page-aliases: ROOT:encrypting-using-sdk.adoc
 
 [abstract]
-A practical guide for getting started with Field-Level Encryption, showing how to encrypt and decrypt JSON fields using the .NET SDK.
+{description}
 
 For a high-level overview of this feature, see the xref:concept-docs:encryption.adoc[Field-Level Encryption discussion doc].
 

--- a/modules/howtos/pages/error-handling.adoc
+++ b/modules/howtos/pages/error-handling.adoc
@@ -1,11 +1,12 @@
 = Handling Errors with the .NET SDK
+:description: Common errors and exceptions, and how to handle them.
 :navtitle: Handling Errors
 :page-topic-type: howto
 :page-aliases: ROOT:handling-error-conditions,handling-error-conditions,errors,handling-errors
 :source-language: csharp
 
 [abstract]
-Common errors and exceptions, and how to handle them.
+{description}
 
 
 

--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -1,11 +1,12 @@
 = Full Text Search (FTS) Using the .NET SDK with Couchbase Server
+:description: You can use the Full Text Search service (FTS) to create queryable full-text indexes in Couchbase Server.
 :navtitle: Searching from the SDK
 :page-topic-type: howto
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-You can use the Full Text Search service (FTS) to create queryable full-text indexes in Couchbase Server.
+{description}
 
 
 

--- a/modules/howtos/pages/health-check.adoc
+++ b/modules/howtos/pages/health-check.adoc
@@ -1,9 +1,10 @@
 = Diagnosing and preventing Network Problems with Health Check
+:description: In today's distributed and virtual environments, users will often not have full administrative control over their whole network.
 :navtitle: Health Check
 :page-topic-type: howto
 
 [abstract]
-In today's distributed and virtual environments, users will often not have full administrative control over their whole network. 
+{description}
 Health Check introduces _Ping_ to check nodes are still healthy, and to force idle connections to be kept alive in environments with eager shutdowns of unused resources.
 _Diagnostics_ requests a report from a node, giving instant health check information.
 

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -1,9 +1,10 @@
 = Key Value Operations
+:description: link:project-docs:partial$attributes.adoc[]
 :navtitle: KV Operations
 :page-topic-type: howto
 :page-aliases: document-operations.adoc
 
-include::project-docs:partial$attributes.adoc[]
+{description}
 
 // The complete code sample used on this page can be downloaded from
 //  xref::example$document.cs[here]

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -1,4 +1,5 @@
 = Managing Connections using the .NET SDK with Couchbase Server
+:description: This section describes how to connect the .NET SDK to a Couchbase cluster.
 :navtitle: Managing Connections
 :page-topic-type: howto
 :page-aliases: ROOT:managing-connections,howtos:multi-network,ROOT:connecting,ROOT:connection-advanced,ROOT:cluster-helper
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-This section describes how to connect the .NET SDK to a Couchbase cluster.
+{description}
 It contains best practices as well as information on TLS/SSL and other advanced connection options.
 
 == Connecting to a Cluster

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -1,4 +1,5 @@
 = N1QL Queries from the SDK
+:description: You can query for documents in Couchbase using the N1QL query language, a language based on SQL, but designed for structured and flexible JSON documents.
 :navtitle: N1QL from the SDK
 :page-topic-type: howto
 :page-aliases: n1ql-query
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-You can query for documents in Couchbase using the N1QL query language, a language based on SQL, but designed for structured and flexible JSON documents.
+{description}
 Querying can solve typical programming tasks such as finding a user profile by email address, facebook login, or user ID.
 
 

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -1,11 +1,12 @@
 = Provisioning Cluster Resources
+:description: Provisioning cluster resources is managed at the collection or bucket level, depending upon the service affected.
 :navtitle: Provisioning Cluster Resources
 :page-aliases: ROOT:managing-clusters
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Provisioning cluster resources is managed at the collection or bucket level, depending upon the service affected.
+{description}
 Common use cases are outlined here, less common use cases are covered in the https://pkg.go.dev/github.com/couchbase/gocb/v2?tab=doc[API docs].
 
 include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=management-intro]

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -1,4 +1,5 @@
 = Authenticating against Couchbase Server
+:description: As well as Role-Based Access Control (RBAC), Couchbase offers connection with Certificate Authentication, and works transparently with LDAP.
 :page-topic-type: howto
 :page-edition: Enterprise Edition
 :page-aliases: ROOT:sdk-authentication-overview
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-As well as Role-Based Access Control (RBAC), Couchbase offers connection with Certificate Authentication, and works transparently with LDAP.
+{description}
 
 
 Our xref:hello-world:start-using-sdk.adoc[Getting Started] guide covered the basics for authorizing against a Couchbase cluster, but you may need to use alternative authentication methods such as Certification.

--- a/modules/howtos/pages/sdk-user-management-example.adoc
+++ b/modules/howtos/pages/sdk-user-management-example.adoc
@@ -1,9 +1,10 @@
 = User Management
+:description: pass:q[The .NET SDK lets you create _users_, assign them _roles_ and associated _privileges_, and remove them from the system.]
 :navtitle: Provisioning Cluster Resources
 :page-aliases: ROOT:sdk-user-management-example.adoc
 
 [abstract]
-The .NET SDK lets you create _users_, assign them _roles_ and associated _privileges_, and remove them from the system.
+{description}
 
 == User-Management APIs
 

--- a/modules/howtos/pages/slow-operations-logging.adoc
+++ b/modules/howtos/pages/slow-operations-logging.adoc
@@ -1,9 +1,10 @@
 = Slow Operations Logging
+:description: Tracing information on slow operations can be found in the logs as threshold logging, orphan logging, and other span metrics.
 :page-topic-type: howto
 // :page-aliases: ROOT:
 
 [abstract]
-Tracing information on slow operations can be found in the logs as threshold logging, orphan logging, and other span metrics.
+{description}
 Change the settings to alter how much information you collect
 
 To improve debuggability certain metrics are automatically measured and logged.

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -1,4 +1,5 @@
 = Sub-Document Operations with the .NET SDK
+:description: Sub-Document operations can be used to efficiently access and change parts of documents.
 :navtitle: Sub-Doc Operations
 :page-topic-type: howto
 :lang: csharp
@@ -7,7 +8,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Sub-Document operations can be used to efficiently access and change parts of documents.
+{description}
 
 
 

--- a/modules/howtos/pages/tracing-from-the-sdk.adoc
+++ b/modules/howtos/pages/tracing-from-the-sdk.adoc
@@ -1,9 +1,10 @@
 = Tracing from the .NET SDK
+:description: Threshold logging
 :navtitle: Tracing from the SDK
 :page-topic-type: howto
 
 [abstract]
-Threshold logging
+{description}
 
 // https://issues.couchbase.com/browse/DOC-4791 - 
 

--- a/modules/howtos/pages/transcoders-nonjson.adoc
+++ b/modules/howtos/pages/transcoders-nonjson.adoc
@@ -1,9 +1,10 @@
 = Transcoders & Non-JSON Documents
+:description: The .NET SDK supports common JSON document requirements out-of-the-box.
 :nav-title: Using Transcoders
 :page-topic-type: howtos
 
 [abstract]
-The .NET SDK supports common JSON document requirements out-of-the-box.
+{description}
 Custom transcoders and serializers provide support for applications needing to perform advanced operations, including supporting non-JSON data.
 
 The .NET SDK uses the concepts of transcoders and serializers, which are used whenever data is sent to or retrieved from Couchbase Server.

--- a/modules/howtos/pages/view-queries-with-sdk.adoc
+++ b/modules/howtos/pages/view-queries-with-sdk.adoc
@@ -1,4 +1,5 @@
 = MapReduce Views Using the .NET SDK with Couchbase Server
+:description: You can use MapReduce views to create queryable indexes in Couchbase Data Platform.
 :navtitle: MapReduce Views
 :page-topic-type: howto
 :page-aliases: ROOT:view-queries-with-sdk
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-You can use MapReduce views to create queryable indexes in Couchbase Data Platform.
+{description}
 
 include::{version-server}@sdk:shared:partial$views.adoc[tag=deprecate]
 

--- a/modules/project-docs/pages/3.0-pre-release-notes.adoc
+++ b/modules/project-docs/pages/3.0-pre-release-notes.adoc
@@ -1,10 +1,11 @@
 = Pre-release Archive Release Notes
+:description: Release notes for the 3.0 Alpha & Beta Releases
 :navtitle: α & β Release Notes
 :page-topic-type: project-doc
 :page-aliases: 3.0αλφα-sdk-release-notes
 
 [abstract] 
-Release notes for the 3.0 Alpha & Beta Releases
+{description}
 
 In the run-up to the SDK 3.0 API releases, several αλφα and βετα releases were made.
 Their release notes are maintained here for archive purposes.

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -1,12 +1,13 @@
 = Compatibility of Couchbase Features, Couchbase Server Versions, and the Couchbase .NET SDK
+:description: Features available in different SDK versions, and compatibility between Server and SDK. \
+Plus notes on Cloud, networks, and AWS Lambda.
 :navtitle: Compatibility
 :page-aliases: ROOT:overview,ROOT:compatibility-versions-features,compatibility-versions-features
 
 include::partial$attributes.adoc[]
 
 [abstract]
-Features available in different SDK versions, and compatibility between Server and SDK.
-Plus notes on Cloud, networks, and AWS Lambda.
+{description}
 
 
 == Couchbase Version/SDK Version Matrix

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -1,4 +1,6 @@
 = Migrating from SDK2 to SDK3 API
+:description: The 3.0 API breaks the existing 2.0 APIs in order to provide a number of improvements. \
+Collections and Scopes are introduced.
 :nav-title: Migrating to .NET SDK 3.0 API
 :page-topic-type: concept
 :page-aliases: ROOT:migrate
@@ -6,8 +8,7 @@
 include::partial$attributes.adoc[]
 
 [abstract]
-The 3.0 API breaks the existing 2.0 APIs in order to provide a number of improvements.
-Collections and Scopes are introduced.
+{description}
 The Document class and structure has been completely removed from the API, and the returned value is now `Result`.
 Retry behavior is more proactive, and lazy bootstrapping moves all error handling to a single place.
 Individual behaviour changes across services are explained here.

--- a/modules/project-docs/pages/sdk-licenses.adoc
+++ b/modules/project-docs/pages/sdk-licenses.adoc
@@ -1,10 +1,11 @@
 = SDK License
+:description: Couchbase SDKs' source code is licensed under the Apache Licence 2.0. \
+Dependencies carry their own licenses.
 :page-topic-type: project-doc
 :page-aliases: ROOT:sdk-licenses.adoc
 
 [abstract]
-Couchbase SDKs' source code is licensed under the Apache Licence 2.0.
-Dependencies carry their own licenses.
+{description}
 
 The Couchbase .NET Client is distributed as source under the https://www.apache.org/licenses/LICENSE-2.0[Apache License, Version 2.0].
 

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -1,4 +1,5 @@
 = Couchbase .NET SDK Release Notes and Archives
+:description: Release notes, installation instructions, and download archive for the Couchbase .NET Client.
 :navtitle: Release Notes
 :page-topic-type: project-doc
 :page-aliases: relnotes-dotnet-sdk
@@ -6,7 +7,7 @@
 
 // tag::all[]
 [abstract]
-Release notes, installation instructions, and download archive for the Couchbase .NET Client.
+{description}
 
 include::hello-world:partial$supported.adoc[]
 

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -1,4 +1,5 @@
 = Client Settings for the .NET SDK
+:description: pass:q[The `ClusterOptions` class enables you to configure .NET SDK options for bootstrapping, timeouts, reliability, and performance.]
 :nav-title: Client Settings
 :page-topic-type: reference
 :page-aliases: ROOT:client-settings, ROOT:env-config, ROOT:configuring-the-client
@@ -6,7 +7,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-The `ClusterOptions` class enables you to configure .NET SDK options for bootstrapping, timeouts, reliability, and performance. You can configure the client programmatically using JSON config files, Environmental variables settings,  XML based configuration such has app.config or web.config files.
+{description} You can configure the client programmatically using JSON config files, Environmental variables settings,  XML based configuration such has app.config or web.config files.
 
 == Configuration Basics
 

--- a/modules/ref/pages/error-codes.adoc
+++ b/modules/ref/pages/error-codes.adoc
@@ -1,11 +1,12 @@
 = Errors & Exceptions Reference
+:description: The standardized error codes returned by the Couchbase .NET SDK, from cloud connection to sub-document.
 :nav-title: Error Codes
 :page-topic-type: ref
 
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-The standardized error codes returned by the Couchbase .NET SDK, from cloud connection to sub-document.
+{description}
 
 include::{version-server}@sdk:shared:partial$error-ref.adoc[tag=intro]
 


### PR DESCRIPTION
This PR updates all of our .adoc files to ensure we have a `:description:` attribute across our documentation pages.
This is leftover from the original ticket: https://issues.couchbase.com/browse/DOC-8463

Tracked here: https://issues.couchbase.com/browse/DOC-8952