### PR TITLE
DOC-9355: Fix Descriptionizer Regression

### DIFF
--- a/modules/concept-docs/pages/concepts.adoc
+++ b/modules/concept-docs/pages/concepts.adoc
@@ -1,9 +1,9 @@
 = Concepts
-:description: link:project-docs:partial$attributes.adoc[]
+:description: Concepts
 :navtitle: Concepts
 :page-topic-type: landing-page
+include::project-docs:partial$attributes.adoc[]
 
-{description}
 
 include::{version-server}@sdk:shared:partial$concepts.adoc[tag=concepts]
 

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -1,10 +1,10 @@
 = Key Value Operations
-:description: link:project-docs:partial$attributes.adoc[]
+:description: Key Value Operations
 :navtitle: KV Operations
 :page-topic-type: howto
 :page-aliases: document-operations.adoc
+include::project-docs:partial$attributes.adoc[]
 
-{description}
 
 // The complete code sample used on this page can be downloaded from
 //  xref::example$document.cs[here]


### PR DESCRIPTION
Looks like Descriptionizer run in
https://github.com/couchbase/docs-sdk-dotnet/pull/210/
had 2 failures where there was no `[Abstract]`, and the
attribute.adoc link was pulled in instead