### PR TITLE
DOC-9636: Document new RawBinaryTranscoder features in .NET SDK 3.2.6

### DIFF
--- a/modules/howtos/pages/transcoders-nonjson.adoc
+++ b/modules/howtos/pages/transcoders-nonjson.adoc
@@ -145,21 +145,40 @@ include::example$Transcoding.cs[tag=string,indent=0]
 The RawBinaryTranscoder provides the ability for the user to explicitly store and retrieve raw byte data to Couchbase.
 The transcoder does not perform any form of real transcoding, and does not take a serializer, but rather passes the data through and assigns the appropriate binary Common Flag.
 
-[cols="3", options="header"]
+[cols="4", options="header"]
 |===
 |Item
-|Result
+|Encoding Result
+|Decoding Result
 |Common Flag
 
 |String
+|InvalidArgumentException
 |InvalidArgumentException
 |-
 
 |byte[]
 |Passthrough
+|Passthrough
+|Binary
+
+|Memory<byte>
+|Passthrough (≥ 3.2.6)
+|InvalidArgumentException
+|Binary
+
+|ReadOnlyMemory<byte>
+|Passthrough (≥ 3.2.6)
+|InvalidArgumentException
+|Binary
+
+|IMemoryOwner<byte>
+|InvalidArgumentException
+|Passthrough (≥ 3.2.6)
 |Binary
 
 |Other `Object`
+|InvalidArgumentException
 |InvalidArgumentException
 |-
 |===
@@ -169,6 +188,15 @@ Here’s an example of using the `RawBinaryTranscoder`:
 [source,csharp]
 ----
 include::example$Transcoding.cs[tag=binary,indent=0]
+----
+
+From version 3.2.6, the `RawBinaryTranscoder` will accept `Memory<byte>` and `ReadOnlyMemory<byte>` inputs
+and can return `IMemoryOwner<byte>` outputs. Using these types may improve performace by not allocating
+large, temporary `byte[]` arrays on the heap.
+
+[source,csharp]
+----
+include::example$Transcoding.cs[tag=binary-memory,indent=0]
 ----
 
 == Custom Transcoders and Serializers

--- a/modules/howtos/pages/transcoders-nonjson.adoc
+++ b/modules/howtos/pages/transcoders-nonjson.adoc
@@ -143,44 +143,40 @@ include::example$Transcoding.cs[tag=string,indent=0]
 
 === RawBinaryTranscoder
 The RawBinaryTranscoder provides the ability for the user to explicitly store and retrieve raw byte data to Couchbase.
-The transcoder does not perform any form of real transcoding, and does not take a serializer, but rather passes the data through and assigns the appropriate binary Common Flag.
+The transcoder does not perform any form of real transcoding, and does not take a serializer, but rather passes the data through and assigns the appropriate `Binary` Common Flag (except in the case of an exception).
 
-[cols="4", options="header"]
+[cols="3", options="header"]
 |===
 |Item
 |Encoding Result
 |Decoding Result
-|Common Flag
 
 |String
 |InvalidArgumentException
 |InvalidArgumentException
-|-
 
 |byte[]
 |Passthrough
 |Passthrough
-|Binary
 
 |Memory<byte>
-|Passthrough (≥ 3.2.6)
+|Passthrough +
+(from 3.2.6)
 |InvalidArgumentException
-|Binary
 
 |ReadOnlyMemory<byte>
-|Passthrough (≥ 3.2.6)
+|Passthrough +
+(from 3.2.6)
 |InvalidArgumentException
-|Binary
 
 |IMemoryOwner<byte>
 |InvalidArgumentException
-|Passthrough (≥ 3.2.6)
-|Binary
+|Passthrough +
+(from 3.2.6)
 
 |Other `Object`
 |InvalidArgumentException
 |InvalidArgumentException
-|-
 |===
 
 Here’s an example of using the `RawBinaryTranscoder`:
@@ -190,9 +186,8 @@ Here’s an example of using the `RawBinaryTranscoder`:
 include::example$Transcoding.cs[tag=binary,indent=0]
 ----
 
-From version 3.2.6, the `RawBinaryTranscoder` will accept `Memory<byte>` and `ReadOnlyMemory<byte>` inputs
-and can return `IMemoryOwner<byte>` outputs. Using these types may improve performace by not allocating
-large, temporary `byte[]` arrays on the heap.
+From version 3.2.6, the `RawBinaryTranscoder` will accept `Memory<byte>` and `ReadOnlyMemory<byte>` inputs and can return `IMemoryOwner<byte>` outputs.
+Using these types may improve performance by not allocating large, temporary `byte[]` arrays on the heap.
 
 [source,csharp]
 ----


### PR DESCRIPTION
Motivation
----------
As of .NET SDK 3.2.6 the RawBinaryTranscoder supports additional types
besides byte[] that offer greater performance when dealing with large
binary objects.

Modifications
-------------
Add documentation and an example that cover encoding of `Memory<byte>`
and `ReadOnlyMemory<byte>` and decoding of `IMemoryOwner<byte>`.

Results
-------
This "hidden" performance feature is now documented.