### PR TITLE
Update migrating-sdk-code-to-3.n.adoc

### DIFF
--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -118,14 +118,7 @@ var options = new ClusterOptions
 };
 ----
 
-The configuration options are passed into the `Cluster` object via a constructor:
-
-[source,csharp]
-----
-var cluster = new Cluster("couchbase://localhost", options);
-----
-
-Or by using one of the static `Cluster.ConnectAsync(...)` methods:
+The configuration options are passed into one of the static `Cluster.ConnectAsync(...)` methods:
 
 [source,csharp]
 ----


### PR DESCRIPTION
Removed constructor initialization via the CTOR as its internal and the static ConnectAsync method is the way to do this.