### PR TITLE
AV-35207 -  Restructure Distributed ACID Transactions documentation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -16,10 +16,18 @@
 * xref:howtos:full-text-searching-with-sdk.adoc[Search]
 * xref:howtos:view-queries-with-sdk.adoc[MapReduce Views]
 
+.Transactions
+* xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[How-to Guide]
+** xref:howtos:transactions-single-query.adoc[Single Query Transactions]
+// TODO: Add this for .NET when available
+//** xref:howtos:transactions-tracing.adoc[Tracing]
+* xref:concept-docs:transactions.adoc[Key Concepts]
+** xref:concept-docs:transactions-cleanup.adoc[Cleanup]
+** xref:concept-docs:transactions-error-handling.adoc[Error Handling]
+
 .Advanced Data Operations
 * xref:howtos:concurrent-async-apis.adoc[Async & React APIs]
 * xref:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations]
-* xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions]
 * xref:howtos:encrypting-using-sdk.adoc[Encrypting Your Data]
 * xref:howtos:transcoders-nonjson.adoc[Transcoders & Non-JSON]
 * xref:howtos:working-with-collections.adoc[Working with Collections]

--- a/modules/concept-docs/pages/errors.adoc
+++ b/modules/concept-docs/pages/errors.adoc
@@ -30,4 +30,4 @@ include::{version-server}@sdk:shared:partial$errors.adoc[tag=observability]
 
 == ACID Transactions
 
-For a discussion of errors affecting multi-document ACID transactions, see xref:howtos:distributed-acid-transactions-from-the-sdk.adoc#error-handling[our documentation on transactions from the .NET SDK].
+For a discussion of errors affecting multi-document ACID transactions, see xref:concept-docs:transactions-error-handling.adoc#error-handling[our documentation on transactions from the .NET SDK].

--- a/modules/concept-docs/pages/transactions-cleanup.adoc
+++ b/modules/concept-docs/pages/transactions-cleanup.adoc
@@ -1,0 +1,47 @@
+= Cleanup
+:description: The SDK takes care of failed or lost transactions, using an asynchronous cleanup background task.
+:page-toclevels: 2
+:page-pagination: full
+
+[abstract]
+{description}
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=cleanup;!integrated-sdk-cleanup-collections]
+
+[#tuning-cleanup]
+=== Configuring Cleanup
+
+The cleanup settings can be configured as so:
+
+[options="header"]
+|===
+|Setting|Default|Description
+|`CleanupWindow`|60 seconds|This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents.  It is perfectly valid for the application to change this setting, which is at a conservative default.  Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
+|`CleanupLostAttempts`|true|This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client.  It is strongly recommended that it is left enabled.
+|`CleanupClientAttempts`|true|This thread is for cleaning up transactions created just by this client.  The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash).  It is strongly recommended that it is left enabled.
+|===
+
+// TODO: Add this for .NET when available
+////
+=== Monitoring Cleanup
+
+If the application wishes to monitor cleanup it may subscribe to these events:
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=cleanup-events,indent=0]
+----
+
+`TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
+(A run is typically around every 60 seconds, with default configuration.)
+
+A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
+It contains whether that attempt was successful, along with any logs relevant to the attempt.
+
+In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
+With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
+If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.
+////

--- a/modules/concept-docs/pages/transactions-error-handling.adoc
+++ b/modules/concept-docs/pages/transactions-error-handling.adoc
@@ -1,0 +1,36 @@
+= Error Handling
+:description:  Handling transaction errors with Couchbase.
+:page-toclevels: 2
+:page-pagination: prev
+
+[abstract]
+{description}
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error-intro]
+
+== Transaction Errors
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
+
+[source,csharp]
+----
+include::howtos:example$TransactionsExample.cs[tag=config-expiration,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
+
+Similar to `TransactionResult`, `SingleQueryTransactionResult` also has an `UnstagingComplete` property.
+
+=== Full Error Handling Example
+
+Pulling all of the above together, this is the suggested best practice for error handling:
+
+[source,csharp]
+----
+include::howtos:example$TransactionsExample.cs[tag=full-error-handling,indent=0]
+----

--- a/modules/concept-docs/pages/transactions.adoc
+++ b/modules/concept-docs/pages/transactions.adoc
@@ -1,0 +1,70 @@
+= Distributed ACID Transactions
+:description:  A high-level overview of Distributed ACID Transactions with Couchbase.
+:page-toclevels: 2
+:page-pagination: next
+
+include::project-docs:partial$attributes.adoc[]
+include::howtos:partial$acid-transactions-attributes.adoc[]
+
+[abstract]
+{description}
+
+For a practical guide, see xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions from the Java SDK].
+
+== Overview
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=intro]
+
+== Transaction Mechanics
+
+[source,csharp]
+----
+include::howtos:example$TransactionsExample.cs[tag=create-simple,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!integrated-sdk-cleanup-process]
+
+TIP: Committing is automatic: if there is no explicit call to `ctx.CommitAsync()` at the end of the transaction logic callback, and no exception is thrown, it will be committed.
+
+=== Rollback
+
+When an exception is thrown, either by the application from the {lambda}, or by the transactions logic itself (e.g. on a failed operation), then that attempt is rolled back.
+
+The application's {lambda} may or may not be retried, depending on the error that occurred.
+The general rule for retrying is whether the transaction is likely to succeed on a retry.
+For example, if this transaction is trying to write a document that is currently involved in another transaction (a write-write conflict), this will lead to a retry as that is likely a transient state.
+But if the transaction is trying to get a document that does not exist, it will not retry.
+
+If the transaction is not retried then it will throw a `{transaction-failed}`.
+
+[source,csharp]
+----
+include::howtos:example$TransactionsExample.cs[tag=rollback-cause,indent=0]
+----
+
+The transaction can also be explicitly rolled back:
+
+[source,csharp]
+----
+include::howtos:example$TransactionsExample.cs[tag=rollback,indent=0]
+----
+
+In this case, if `ctx.RollbackAsync()` is reached, then the transaction will be regarded as successfully rolled back and no `{transaction-failed}` will be thrown.
+
+After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the SDK will not try to automatically commit it at the end of the code block.
+
+== Transaction Operations
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query;!integrated-sdk-begin-transaction]
+
+== Custom Metadata Collections
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1]
+
+[source,csharp]
+----
+include::howtos:example$TransactionsExample.cs[tag=custom-metadata,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-2]
+

--- a/modules/howtos/examples/Couchbase.Examples/Couchbase.Examples.csproj
+++ b/modules/howtos/examples/Couchbase.Examples/Couchbase.Examples.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.1.3" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.3.4" />
     <PackageReference Include="Couchbase.Extensions.Encryption" Version="2.0.0-dp.1" />
-    <PackageReference Include="MessagePack" Version="2.2.85" />
+    <PackageReference Include="MessagePack" Version="2.4.35" />
   </ItemGroup>
 
 </Project>

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -1,9 +1,10 @@
 = Distributed Transactions from the .NET SDK
-:description: A practical guide to using Couchbase's distributed ACID transactions, via the .NET API.
+:description: A practical guide to using Couchbase's distributed ACID transactions, via the .NET SDK.
 :navtitle: ACID Transactions
 :page-topic-type: howto
-:page-aliases: acid-transactions.adoc
+:page-aliases: acid-transactions
 :page-toclevels: 2
+:page-pagination: next
 
 include::project-docs:partial$attributes.adoc[]
 include::partial$acid-transactions-attributes.adoc[]
@@ -11,412 +12,116 @@ include::partial$acid-transactions-attributes.adoc[]
 [abstract]
 {description}
 
+This guide will show you examples of how to perform multi-document ACID (atomic, consistent, isolated, and durable) database transactions within your application, using the Couchbase .NET SDK and transactions library.
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=intro]
+Refer to the xref:concept-docs:transactions.adoc[Distributed ACID Transactions] concept material for a high-level overview.
 
+== Prerequisites
 
-Below we show you how to create Transactions, step-by-step.
-You may also want to start with our https://github.com/couchbaselabs/couchbase-transactions-dotnet-examples[transactions examples repository],
-which features useful downloadable examples of using Distributed Transactions.
+[{tabs}]
+====
+Couchbase Capella::
++
+--
+* Couchbase Capella account.
+* You should know how to perform xref:howtos:kv-operations.adoc[key-value] or xref:howtos:n1ql-queries-with-sdk.adoc[query] operations with the SDK.
+* Your application should have the relevant roles and permissions on the required buckets, scopes, and collections, to perform transactional operations.
+Refer to the xref:cloud:organizations:organization-projects-overview.adoc[Organizations & Access] page for more details.
+* If your application is using xref:concept-docs:xattr.adoc[extended attributes (XATTRs)], you should avoid using the XATTR field `txn` -- this is reserved for Couchbase use.
+--
 
-API Docs are available https://docs.couchbase.com/sdk-api/couchbase-transactions-dotnet/[online].
+Couchbase Server::
++
+--
+* Couchbase Server (6.6.2 or above).
+* You should know how to perform xref:howtos:kv-operations.adoc[key-value] or xref:howtos:n1ql-queries-with-sdk.adoc[query] operations with the SDK.
+* Your application should have the relevant roles and permissions on the required buckets, scopes, and collections, to perform transactional operations.
+Refer to the xref:{version-server}@server:learn:security/roles.adoc[Roles] page for more details.
+* If your application is using xref:concept-docs:xattr.adoc[extended attributes (XATTRs)], you should avoid using the XATTR field `txn` -- this is reserved for Couchbase use.
+* NTP should be configured so nodes of the Couchbase cluster are in sync with time.
+--
+====
 
-
-== Requirements
-
-* Couchbase Server 6.6.2 or above.
-* Couchbase .NET client 3.2.3 or above.
-It is recommended you use the package on NuGet.
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
-
-== Getting Started
+// TODO: Remove this once the SDK uses integrated transactions, instead of the library.
+=== Transactions Library
 
 Couchbase transactions require no additional components or services to be configured.
 Simply add the transactions library into your project.
-Version 1.1.0 was release October 29th, 2021.
+Version `1.1.0` was released October 29th, 2021. +
 See the xref:project-docs:distributed-transactions-dotnet-release-notes.adoc[Release Notes] for the latest version.
 
-With NuGut this can be accomplished by using the NuGet Package Manager in your IDE:
+.Installation
+[{tabs}]
+====
+NuGet::
++
+--
+With NuGet this can be accomplished by using the NuGet Package Manager in your IDE:
 
-[source]
 ----
 PM > Install-Package Couchbase.Transactions -Version 1.1.0
 ----
+--
 
-Or via the CLI
+CLI::
++
+--
+You can also install the library with the dotnet CLI.
 
-[source]
+[source,console]
 ----
-dotnet add package Couchbase.Transactions --version 1.1.0
+$ dotnet add package Couchbase.Transactions --version 1.1.0
 ----
+--
 
-Or by using PackageReference in your .csproj file:
+.csproj file::
++
+--
+If you're using a .csproj file, add this `PackageReference`:
 
-[source]
+[source,xml]
 ----
 <PackageReference Include="Couchbase.Transactions" Version="1.1.0" />
 ----
+--
+====
+// End TODO
 
-A complete simple NuGet example is available on our https://github.com/couchbaselabs/couchbase-transactions-dotnet-examples[transactions examples repository].
+== Creating a Transaction
 
-
-== Initializing Transactions
-
-Here are all imports used by the following examples:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=imports,indent=0]
-----
-
+// TODO: Remove this once the SDK uses integrated transactions, instead of the library.
 The starting point is the `Transactions` object.
-It is very important that the application ensures that only one of these is created per cluster, as it performs automated background clean-up processes that should not be duplicated.
-In dependency injection context, this instance should be injected as a singleton.
+It is very important that an application ensures that only one of these is created per cluster, as it performs automated background clean-up processes that should not be duplicated.
+In a dependency injection context, this instance should be injected as a singleton.
 
 [source,csharp]
 ----
 include::example$TransactionsExample.cs[tag=init,indent=0]
 ----
-
-=== Multiple Transactions Objects
-
-Generally an application will need just one `Transactions` object, and in fact the library will usually warn if more are created.
-Each `Transactions` object uses some resources, including a thread-pool.
-
-There is one rare exception where an application may need to create multiple `Transactions` objects, which is covered in <<Custom Metadata Collections>>.
-
-== Configuration
-
-Transactions can optionally be configured at the point of creating the `Transactions` object:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=config,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
-
+// End TODO
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating]
-
-As with the Couchbase .NET Client, you should use the library asynchronusly using the async/await keywords (the exceptions will be explained later in <<Error Handling>>):
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=create,indent=0]
-----
-
-The asynchronous API allows you to use the thread pool, which can help you scale with excellent efficiency.
-However, operations inside an individual transaction should be kept in-order and executed using `await` immediately.
-Do not use fire-and-forget tasks under any circumstances.
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
-
-// Examples
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=examples-intro]
 
 [source,csharp]
 ----
 include::example$TransactionsExample.cs[tag=examples,indent=0]
 ----
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!integrated-sdk-cleanup-process]
-
-
-== Key-Value Mutations
-
-=== Replacing
-
-Replacing a document requires awaiting a `TransactionGetResult` returned from `ctx.GetAsync()`, `ctx.InsertAsync()`, or another `ctx.ReplaceAsync()` call first.
-This is necessary to ensure that the document is not involved in another transaction.
-(If it is, then the transaction will handle this, generally by rolling back what has been done so far, and retrying the lambda.)
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=replace,indent=0]
-----
-
-=== Removing
-
-As with replaces, removing a document requires awaiting a `TransactionGetResult` from a previous transaction operation first.
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=remove,indent=0]
-----
-
-=== Inserting
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=insert,indent=0]
-----
-
-== Key-Value Reads
-
-There are two ways to get a document, `GetAsync` and `GetOptionalAsync`:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=get,indent=0]
-----
-
-`GetAsync` will cause the transaction to fail with `TransactionFailedException` (after rolling back any changes, of course).
-It is provided as a convenience method so the developer does not have to check for `null` if the document must exist for the transaction to succeed.
-
-Gets will 'read your own writes', e.g. this will succeed:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=getReadOwnWrites,indent=0]
-----
-
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query-intro;!integrated-sdk-begin-transaction]
-
-=== Using N1QL
-
-If you already use N1QL from the .NET SDK, then its use in transactions is very similar.
-It returns the same `IQueryResult<T>` you are used to, and takes most of the same options.
-
-You must take care to write `ctx.QueryAsync()` inside the lambda however, rather than `cluster.QueryAsync()` or `scope.QueryAsync()`.
-
-An example of selecting some rows from the `travel-sample` bucket:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=queryExamplesSelect,indent=0]
-----
-
-Rather than specifying the full "`travel-sample`.inventory.hotel" name each time, it is easier to pass a reference to the inventory `IScope`:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=queryExamplesSelectScope,indent=0]
-----
-
-An example using a `IScope` for an UPDATE:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=queryExamplesUpdate,indent=0]
-----
-
-And an example combining SELECTs and UPDATEs.
-It's possible to call regular C# methods from the lambda, as shown here, permitting complex logic to be performed.
-Just remember that since the lambda may be called multiple times, so may the method.
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=queryExamplesComplex,indent=0]
-----
-
-=== Read Your Own Writes
-
-As with Key-Value operations, N1QL queries support Read Your Own Writes.
-
-This example shows inserting a document and then selecting it again.
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=queryInsert,indent=0]
-----
-
-<1> The inserted document is only staged at this point. as the transaction has not yet committed.
-Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
-<2> But the SELECT can, as we are reading a mutation staged inside the same transaction.
-
-=== Mixing Key-Value and N1QL
-
-Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
-
-In this example we insert a document with Key-Value, and read it with a SELECT.
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=queryRyow,indent=0]
-----
-<1> As with the 'Read Your Own Writes' example, here the insert is only staged, and so it is not visible to other transactions or non-transactional actors.
-<2> But the SELECT can view it, as the insert was in the same transaction.
-
-=== Query Options
-
-Query options can be provided via `TransactionQueryOptions`, which provides a subset of the options in the .NET SDK's `QueryOptions`.
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=queryOptions,indent=0]
-----
-
-The supported options are:
-
-* Parameter
-* ScanConsistency
-* FlexIndex
-* Serializer
-* ClientContextId
-* ScanWait
-* ScanCap
-* PipelineBatch
-* PipelineCap
-* Readonly
-* AdHoc
-* Raw
-
-See the xref:howtos:n1ql-queries-with-sdk.adoc#query-options[QueryOptions documentation] for details on these.
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-concurrency]
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-perf]
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=query-single]
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=querySingle,indent=0]
-----
-
-You can also run a single query transaction against a particular `IScope` (these examples will exclude the full error handling for brevity):
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=querySingleScoped,indent=0]
-----
-
-and configure it:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=querySingleConfigured,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=n1ql-rbac]
-
-
-== Committing
-
-Committing is automatic: if there is no explicit call to `ctx.CommitAsync()` at the end of the transaction logic callback, and no exception is thrown, it will be committed.
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=commit,indent=0]
-----
-
-As described above, as soon as the transaction is committed, all its changes will be atomically visible to reads from other transactions.
-The changes will also be committed (or "unstaged") so they are visible to non-transactional actors, in an eventually consistent fashion.
-
-Commit is final: after the transaction is committed, it cannot be rolled back, and no further operations are allowed on it.
-
-An asynchronous cleanup process ensures that once the transaction reaches the commit point, it will be fully committed -- even if the application crashes.
-
-
-// == A Full Transaction Example
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=example]
-
-A complete version of this example is available on our https://github.com/couchbaselabs/couchbase-transactions-dotnet-examples[GitHub transactions examples page].
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=full,indent=0]
-----
-
-
-== Rollback
-
-If an exception is thrown, either by the application from the lambda, or by the transactions library, then that attempt is rolled back.
-The transaction logic may or may not be retried, depending on the exception.
-//- see link:#error-handling[Error handling and logging].
-
-If the transaction is not retried then it will throw a `TransactionFailedException` exception, and its `Cause` property can be used for more details on the failure.
-
-The application can use this to signal why it triggered a rollback, as so:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=rollback-cause,indent=0]
-----
-
-The transaction can also be explicitly rolled back:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=rollback,indent=0]
-----
-
-In this case, if `ctx.RollbackAsync()` is reached, then the transaction will be regarded as successfully rolled back and no TransactionFailed will be thrown.
-
-After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the library will not try to automatically commit it at the end of the code block.
-
-
-
-//  Error Handling
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
-
-There are three exceptions that Couchbase transactions can raise to the application:
-`TransactionFailedException`, `TransactionExpiredException` and `TransactionCommitAmbiguousException`.
-All exceptions derive from `TransactionFailedException` for backwards-compatibility purposes.
-
-//  txnfailed
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=config-expiration,indent=0]
-----
-
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
-
-Similar to `TransactionResult`, `SingleQueryTransactionResult` also has an `UnstagingComplete` property.
-
-=== Full Error Handling Example
-
-Pulling all of the above together, this is the suggested best practice for error handling:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=full-error-handling,indent=0]
-----
-
-
-// == Asynchronous Cleanup
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=cleanup;!integrated-sdk-cleanup-collections]
-
-[#tuning-cleanup]
-=== Configuring Cleanup
-
-The cleanup settings can be configured as so:
-
-[options="header"]
-|===
-|Setting|Default|Description
-|`CleanupWindow`|60 seconds|This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents.  It is perfectly valid for the application to change this setting, which is at a conservative default.  Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
-|`CleanupLostAttempts`|true|This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client.  It is strongly recommended that it is left enabled.
-|`CleanupClientAttempts`|true|This thread is for cleaning up transactions created just by this client.  The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash).  It is strongly recommended that it is left enabled.
-|===
-
-////
-=== Monitoring Cleanup
-
-If the application wishes to monitor cleanup it may subscribe to these events:
-
-[source,csharp]
-----
-include::example$TransactionsExample.cs[tag=cleanup-events,indent=0]
-----
-
-`TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
-(A run is typically around every 60 seconds, with default configuration.)
-
-A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
-It contains whether that attempt was successful, along with any logs relevant to the attempt.
-
-In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
-With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
-If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.
-////
-
-
-== Logging
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
+
+[IMPORTANT]
+====
+As with the Couchbase .NET Client, you should use the transactions library asynchronously using the async/await keywords.
+The asynchronous API allows you to use the thread pool, which can help you scale with excellent efficiency.
+However, operations inside an individual transaction should be kept in-order and executed using `await` immediately.
+Do not use fire-and-forget tasks under any circumstances.
+====
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating-error]
+
+=== Logging
 
 To aid troubleshooting, each transaction maintains a list of log entries, which can be logged on failure like this:
 
@@ -425,7 +130,7 @@ To aid troubleshooting, each transaction maintains a list of log entries, which 
 include::example$TransactionsExample.cs[tag=logging,indent=0]
 ----
 
-A failed transaction can involve dozens, even hundreds, of lines of logging, so the application may prefer to write failed transactions into a separate file.
+A failed transaction can involve dozens, even hundreds, of lines of logging, so it may be preferable to write failed transactions into a separate file.
 
 ////
 This will log all lines of any failed transactions, to `WARN` level:
@@ -444,16 +149,176 @@ Here is an example of configuring a `Microsoft.Extensions.Logging.ILoggingFactor
 include::example$TransactionsExample.cs[tag=full-logging,indent=0]
 ----
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1]
+== Key-Value Operations
+
+You can perform transactional database operations using familiar key-value CRUD methods:
+
+* **C**reate - `InsertAsync()`
+
+* **R**ead - `GetAsync()` or `GetOptionalAsync()`
+
+* **U**pdate - `ReplaceAsync()`
+
+* **D**elete - `RemoveAsync()`
+
+[IMPORTANT]
+====
+As mentioned <<lambda-ops,previously>>, make sure your application uses the transactional key-value operations inside the {lambda} -- such as `ctx.InsertAsync()`, rather than `collection.InsertAsync()`.
+====
+
+=== Insert
+
+To insert a document within a transaction {lambda}, simply call `ctx.InsertAsync()`.
 
 [source,csharp]
 ----
-include::example$TransactionsExample.cs[tag=custom-metadata,indent=0]
+include::example$TransactionsExample.cs[tag=insert,indent=0]
 ----
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-2]
+=== Get
 
-== Further Reading
+There are two ways to get a document, `GetAsync` and `GetOptionalAsync`:
 
-* There's plenty of explanation about how Transactions work in Couchbase in our xref:7.1@server:learn:data/transactions.adoc[Transactions documentation].
-* You can find further code examples on our https://github.com/couchbaselabs/couchbase-transactions-dotnet-examples[transactions examples repository].
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=get,indent=0]
+----
+
+`GetAsync` may return a `TransactionFailedException` if a document doesn't exist, for example.
+It is provided as a convenience method, so a developer does not have to check for `null` if the document must exist for the transaction to succeed -- which is the case with `GetAsyncOptional`.
+
+Gets will "Read Your Own Writes", e.g. this will succeed:
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=getReadOwnWrites,indent=0]
+----
+
+Of course, no other transaction will be able to read that inserted document, until this transaction reaches the commit point.
+
+=== Replace
+
+Replacing a document requires awaiting a `TransactionGetResult` returned from `ctx.GetAsync()`, `ctx.InsertAsync()`, or another `ctx.ReplaceAsync()` call first.
+This is necessary to ensure that the document is not involved in another transaction.
+If it is, then the transaction will handle this, generally by rolling back what has been done so far, and retrying the lambda.
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=replace,indent=0]
+----
+
+=== Remove
+
+As with replaces, removing a document requires awaiting a `TransactionGetResult` from a previous transaction operation first.
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=remove,indent=0]
+----
+
+== {sqlpp} Queries
+
+If you already use https://www.couchbase.com/products/n1ql[{sqlpp} (formerly N1QL)], then its use in transactions is very similar.
+A query returns the same `IQueryResult<T>` you are used to, and takes most of the same options.
+
+[IMPORTANT]
+====
+As mentioned <<lambda-ops,previously>>, make sure your application uses the transactional query operations inside the {lambda} -- such as `ctx.QueryAsync()`, rather than `cluster.QueryAsync()` or `scope.QueryAsync()`.
+====
+
+Here is an example of selecting some rows from the `travel-sample` bucket:
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=queryExamplesSelectScope,indent=0]
+----
+
+An example using a `IScope` for an UPDATE:
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=queryExamplesUpdate,indent=0]
+----
+
+And an example combining `SELECT` and `UPDATE`.
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=queryExamplesComplex,indent=0]
+----
+
+As you can see from the snippet above, it is possible to call regular C# methods from the lambda, permitting complex logic to be performed.
+Just remember that since the {lambda} may be called multiple times, so may the method.
+
+Like key-value operations, queries support "Read Your Own Writes".
+This example shows inserting a document and then selecting it again:
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=queryInsert,indent=0]
+----
+
+<1> The inserted document is only staged at this point, as the transaction has not yet committed. +
+Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
+<2> But the `SELECT` can, as we are reading a mutation staged inside the same transaction.
+
+=== Query Options
+
+Query options can be provided via `TransactionQueryOptions` object:
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=queryOptions,indent=0]
+----
+
+.Supported Transaction Query Options
+|===
+| Name | Description
+
+| `Parameter(Object)` | Allows to set positional arguments for a parameterized query.
+| `Parameters(Object[])` | Allows you to set named arguments for a parameterized query.
+| `ScanConsistency(QueryScanConsistency)` | Sets a different scan consistency for this query.
+| `FlexIndex(Boolean)` | Tells the query engine to use a flex index (utilizing the search service).
+| `Serializer(ITypeSerializer)` | Allows to use a different serializer for the decoding of the rows.
+| `ClientContextId(String)` | Sets a context ID returned by the service for debugging purposes.
+| `ScanWait(TimeSpan)` | Allows to specify a maximum scan wait time.
+| `ScanCap(Int32)` | Specifies a maximum cap on the query scan size.
+| `PipelineBatch(Int32)` | Sets the batch size for the query pipeline.
+| `PipelineCap(Int32)` | Sets the cap for the query pipeline.
+| `Readonly(Boolean)` | Tells the client and server that this query is readonly.
+| `AdHoc(Boolean)` | If set to false will prepare the query and later execute the prepared statement.
+| `Raw(String, Object)` | Escape hatch to add arguments that are not covered by these options.
+|===
+
+== Mixing Key-Value and {sqlpp}
+
+Key-Value and {sqlpp} query operations can be freely intermixed, and will interact with each other as you would expect.
+In this example we insert a document with a key-value operation, and read it with a `SELECT` query.
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=queryRyow,indent=0]
+----
+
+<1> The key-value insert operation is only staged, and so it is not visible to other transactions or non-transactional actors.
+<2> But the `SELECT` can view it, as the insert was in the same transaction.
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=rbac]
+
+== Configuration
+
+The default configuration should be appropriate for most use-cases.
+If needed, transactions can optionally be configured at the point of creating the `Transactions` object:
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=config,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
+
+== Additional Resources
+
+* Learn more about xref:concept-docs:transactions.adoc[Distributed ACID Transactions].
+
+* Check out the Couchbase Transactions library https://docs.couchbase.com/sdk-api/couchbase-transactions-dotnet/[API Reference].

--- a/modules/howtos/pages/transactions-single-query.adoc
+++ b/modules/howtos/pages/transactions-single-query.adoc
@@ -1,0 +1,31 @@
+= Single Query Transactions
+:description: Learn how to perform bulk-loading transactions with the SDK.
+:page-partial:
+:page-topic-type: howto
+:page-pagination: full
+
+include::project-docs:partial$attributes.adoc[]
+
+[abstract]
+{description}
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=single-query-transactions-intro]
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=querySingle,indent=0]
+----
+
+You can also run a single query transaction against a particular `IScope` (these examples will exclude the full error handling for brevity):
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=querySingleScoped,indent=0]
+----
+
+and configure it:
+
+[source,csharp]
+----
+include::example$TransactionsExample.cs[tag=querySingleConfigured,indent=0]
+----

--- a/modules/howtos/partials/acid-transactions-attributes.adoc
+++ b/modules/howtos/partials/acid-transactions-attributes.adoc
@@ -21,3 +21,7 @@
 :transaction-config: TransactionConfigBuilder
 :transaction-commit-ambiguous: TransactionCommitAmbiguousException
 :txnfailed-unstaging-complete: TransactionResult.UnstagingComplete
+
+// lambda
+:lambda: lambda
+:intro-lambda: pass:q[a `lambda`]


### PR DESCRIPTION
Page previews (including sdk-common changes, so it's easier to see it all together):

[Transactions howto guide](https://maria-robobug.github.io/transactions-reorg/dotnet-sdk/3.3/howtos/distributed-acid-transactions-from-the-sdk.html)

[Transactions concept guide](https://maria-robobug.github.io/transactions-reorg/dotnet-sdk/3.3/concept-docs/transactions.html)

NUX improvements:

* Splits howto and concept content as well as removing repetitive
  sections.

* Adds Capella in Prerequisites

* Removes repetitive examples from asciidoc where possible.

* Move Transactions to top level nav, include concept and howto in same section.