### PR TITLE
Updated thresholdOptions.WithInterval to thresholdOptions.WithEmitInterval

### DIFF
--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -441,7 +441,7 @@ The default tracer logs the slowest requests per service.
 var clusterOptions = new ClusterOptions();
   clusterOptions.WithThresholdTracing(thresholdOptions =>
   {
-      thresholdOptions.WithInterval(TimeSpan.FromSeconds(10));
+      thresholdOptions.WithEmitInterval(TimeSpan.FromSeconds(10));
       thresholdOptions.WithSampleSize(10);
       thresholdOptions.WithKvThreshold(TimeSpan.FromMilliseconds(500));
       thresholdOptions.WithQueryThreshold(TimeSpan.FromSeconds(1));


### PR DESCRIPTION
Updated the code for the Threshold Tracer to reflect the proper `thresholdOption` name. 

There was no fix version on the ticket, so I don't know which versions this change might need to be copied back to. Logging against most recent release for now. 