### PR TITLE
DOC-9517 - Backport PR #274 - Updated thresholdOptions.WithInterval to thresholdOptions.WithEmitInterval

### DIFF
--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -441,7 +441,7 @@ The default tracer logs the slowest requests per service.
 var clusterOptions = new ClusterOptions();
   clusterOptions.WithThresholdTracing(thresholdOptions =>
   {
-      thresholdOptions.WithInterval(TimeSpan.FromSeconds(10));
+      thresholdOptions.WithEmitInterval(TimeSpan.FromSeconds(10));
       thresholdOptions.WithSampleSize(10);
       thresholdOptions.WithKvThreshold(TimeSpan.FromMilliseconds(500));
       thresholdOptions.WithQueryThreshold(TimeSpan.FromSeconds(1));


### PR DESCRIPTION
Changed the Threshold Tracer Cluster Option's `thresholdOptions.WithInterval` to `thresholdOptions.WithEmitInterval` per [DOC-9517](https://issues.couchbase.com/browse/DOC-9517). 

This is a backport of PR #274. I created a new commit to improve the commit message from the original commit. :) 