### PR TITLE
Remove NCBC-3635 from 3.4.15

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -40,8 +40,6 @@ https://www.nuget.org/packages/CouchbaseNetClient/3.4.15[Nuget]
 Fixed SDK bugs related to Nullability of Increment, Decrement, and related options.
 * https://issues.couchbase.com/browse/NCBC-3565[NCBC-3565]: 
 Added error handling for "index does not exist" query error.
-* https://issues.couchbase.com/browse/NCBC-3635[NCBC-3635]: 
-`GetAnyReplica: AggregateException` field is now accessible when `DocumentUnretrievableException` is thrown.
 
 ==== New Features and Behavioral Changes
 


### PR DESCRIPTION
NCBC-3635 will be released in 3.5.0 and is not in 3.4.15.